### PR TITLE
doc: fix timer facts variable name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Usage examples for the individual fact plugins included:
 
 - name: Print timer facts
   ansible.builtin.debug:
-    var: aadfinis.factsmers
+    var: ansible_facts.timers
 ```
 
 ### Installing the Collection from Ansible Galaxy


### PR DESCRIPTION
The README is shown on Ansible Galaxy, so it's quite confusing to have this in the README.